### PR TITLE
Remove Wikinews-related commands

### DIFF
--- a/archivebot.sh
+++ b/archivebot.sh
@@ -19,10 +19,6 @@ ${array[*]} -family:wikibooks -lang:es
 ${array[*]} -family:wikibooks -lang:eu
 ${array[*]} -family:wikibooks -lang:gl
 printf '%40s\n' | tr ' ' -
-echo -e "** Wikinews **"
-printf '%40s\n' | tr ' ' -
-${array[*]} -family:wikinews -lang:es
-printf '%40s\n' | tr ' ' -
 echo -e "** Wikipedias **"
 printf '%40s\n' | tr ' ' -
 ${array[*]} -family:wikipedia -lang:an

--- a/clean-sandbox.sh
+++ b/clean-sandbox.sh
@@ -10,7 +10,6 @@ echo -e "Sandbox clearing script started at $(date)."
 printf '%50s\n' | tr ' ' -
 ${command[*]} -pageid:10957461 -text:"{{Meta:Sandbox/Please do not edit this line}}<!-- Please edit below this line -->" -family:meta -lang:meta -delay:15 -summary:"Bot: clearing the sandbox"
 ${command[*]} -pageid:37341 -text:"{{sust:ZDP/2}}" -family:wikibooks -lang:es -delay:15 -summary:"Bot: limpieza automática de la zona de pruebas"
-${command[*]} -pageid:13709 -text:"{{ZDP}}" -family:wikinews -lang:es -delay:15 -summary:"Bot: limpieza automática de la zona de pruebas"
 ${command[*]} -pageid:40294 -text:"{{ZDP}}" -family:wikiquote -lang:es -delay:15 -summary:"Bot: limpieza automática de la zona de pruebas"
 ${command[*]} -pageid:129470,166832,129475,129476,129477 -text:"<!--No borres este mensaje-->{{Zona de pruebas}}<!--Haz las pruebas debajo. Gracias-->" -family:wikisource -lang:es -delay:15 -summary:"Bot: limpieza automática de la zona de pruebas"
 ${command[*]} -pageid:5856 -text:"{{/encabezado}}<!-- REALIZA TUS PRUEBAS DEBAJO DE ESTA LÍNEA -->" -family:wikiversity -lang:es -delay:15 -summary:"Bot: limpieza automática de la zona de pruebas"

--- a/redirects.sh
+++ b/redirects.sh
@@ -28,10 +28,6 @@ ${command[*]} br -namespace:not:2,3 -family:wikibooks -lang:es -delete -sdtempla
 ${command[*]} do -namespace:not:2,3 -family:wikiquote -lang:es -always
 ${command[*]} br -namespace:not:2,3 -family:wikiquote -lang:es -delete -sdtemplate:"{{destruir|1=Bot: redirección rota|bot=sí}}" -always
 
-# Spanish Wikinews
-${command[*]} do -namespace:not:2,3 -family:wikinews -lang:es -always
-${command[*]} br -namespace:not:2,3 -family:wikinews -lang:es -delete -sdtemplate:"{{destruir|1=Bot: redirección rota}}" -always
-
 # Spanish Wikisource
 ${command[*]} do -namespace:not:2,3 -family:wikisource -lang:es -always
 ${command[*]} br -namespace:not:2,3 -family:wikisource -lang:es -delete -sdtemplate:"{{destruir|1=Bot: redirección rota}}" -always


### PR DESCRIPTION
Removing Wikinews-related commands. The project got [closed](https://meta.wikimedia.org/w/index.php?oldid=30328679#Board_of_Trustees_Approves_Closure_of_Wikinews).